### PR TITLE
Fix false-positive checksum, just breaking checksum is enough

### DIFF
--- a/src/Networking/E_Switch.cpp
+++ b/src/Networking/E_Switch.cpp
@@ -64,10 +64,10 @@ void Switch::packetArrived(Port* inPort, Packet* packet)
 						uint16_t checksum;
 						newPacket->readData(14+20+16, &checksum, sizeof(checksum));
 
-						if(checksum != 0xFFFF)
-							checksum = 0xFFFF;
-						else
+						if(checksum != 0xEEEE)
 							checksum = 0xEEEE;
+						else
+							checksum = 0xEEEF;
 
 						newPacket->writeData(14+20+16, &checksum, sizeof(checksum));
 					}

--- a/src/Networking/E_Switch.cpp
+++ b/src/Networking/E_Switch.cpp
@@ -60,7 +60,18 @@ void Switch::packetArrived(Port* inPort, Packet* packet)
 				Packet* newPacket = this->clonePacket(packet);
 				if(drop)
 				{
-					if(newPacket->getSize() >= (14+20+20)) {
+					if(newPacket->getSize() >= (14+20+20+4)) {
+						uint32_t data;
+						newPacket->readData(14+20+20, &data, sizeof(data));
+
+						if(data != 0xEEEEEEEE)
+							data = 0xEEEEEEEE;
+						else
+							data = 0xEEEEEEEF;
+
+						newPacket->writeData(14+20+20, &data, sizeof(data));
+					}
+					else if(newPacket->getSize() >= (14+20+20)) {
 						uint16_t checksum;
 						newPacket->readData(14+20+16, &checksum, sizeof(checksum));
 

--- a/src/Networking/E_Switch.cpp
+++ b/src/Networking/E_Switch.cpp
@@ -60,12 +60,17 @@ void Switch::packetArrived(Port* inPort, Packet* packet)
 				Packet* newPacket = this->clonePacket(packet);
 				if(drop)
 				{
-					uint16_t false_checksum = 0xEEEE;
-					uint32_t false_data = 0xEEEEEEEE;
-					if(newPacket->getSize() >= (14+20+20))
-						newPacket->writeData(14+20+16, &false_checksum, sizeof(false_checksum));
-					if(newPacket->getSize() >= (14+20+20+4))
-						newPacket->writeData(14+20+20, &false_data, sizeof(false_data));
+					if(newPacket->getSize() >= (14+20+20)) {
+						uint16_t checksum;
+						newPacket->readData(14+20+16, &checksum, sizeof(checksum));
+
+						if(checksum != 0xFFFF)
+							checksum = 0xFFFF;
+						else
+							checksum = 0xEEEE;
+
+						newPacket->writeData(14+20+16, &checksum, sizeof(checksum));
+					}
 				}
 				this->sendPacket(port, newPacket);
 			}


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8316406/82831848-7b88e780-9ef4-11ea-9623-74f2b36164d9.png)

In some cases, we can find false positive for packet drop. Breaking checksum is enough to test packet lost without breaking body which make false positive possible.