### PR TITLE
fix a doc error

### DIFF
--- a/include/E/E_System.hpp
+++ b/include/E/E_System.hpp
@@ -186,7 +186,7 @@ public:
     TERMINATED,
   };
   /**
-   * @brief Wake and keep running (CREATED -> READY)
+   * @brief Start and prepare (CREATED -> READY)
    */
   virtual void start() final;
   /**


### PR DESCRIPTION
Runnable::start() is used to `start and wait for preparation`.